### PR TITLE
Merged my latest with dev

### DIFF
--- a/src/hdr_toggle.cpp
+++ b/src/hdr_toggle.cpp
@@ -2,31 +2,49 @@
 #include <algorithm>
 #include <string>
 
-bool _check_status(const NvAPI_Status &s, const std::string &message, bool should_raise) {
-  if (s != NVAPI_OK) {
+bool _check_status(const NvAPI_Status &s, const std::string &message, bool should_raise)
+{
+  if (s != NVAPI_OK)
+  {
     NvAPI_ShortString err_msg;
-    if (NvAPI_GetErrorMessage(s, err_msg) != NVAPI_OK) {
-      if (should_raise) {
+    if (NvAPI_GetErrorMessage(s, err_msg) != NVAPI_OK)
+    {
+      if (should_raise)
+      {
         throw NvapiException(message + std::string("Failed to get NVAPI error message"));
-      } else {
+      }
+      else
+      {
         return false;
       }
     }
-    if (should_raise) {
+    if (should_raise)
+    {
       throw NvapiException(message + std::string("NVAPI Error") + std::string(err_msg));
-    } else {
+    }
+    else
+    {
       return false;
     }
-  } else {
+  }
+  else
+  {
     return true;
   }
 }
 
-HdrToggle::HdrToggle() { check_status(NvAPI_Initialize()); }
+HdrToggle::HdrToggle()
+{
+  check_status(NvAPI_Initialize());
+}
 
-HdrToggle::~HdrToggle() { check_status(NvAPI_Unload()); }
+HdrToggle::~HdrToggle()
+{
+  check_status(NvAPI_Unload());
+}
 
-void HdrToggle::calc_mastering_data(NV_HDR_COLOR_DATA *hdr_data) {
+void HdrToggle::calc_mastering_data(NV_HDR_COLOR_DATA *hdr_data)
+{
   double rx = 0.64;
   double ry = 0.33;
   double gx = 0.30;
@@ -54,15 +72,37 @@ void HdrToggle::calc_mastering_data(NV_HDR_COLOR_DATA *hdr_data) {
   hdr_data->mastering_display_data.min_display_mastering_luminance = (NvU16)ceil(min_master * 10000.0 + 0.5);
 }
 
-NV_HDR_COLOR_DATA HdrToggle::set_hdr_data(bool enabled) {
+NV_HDR_COLOR_DATA HdrToggle::set_hdr_data(bool enabled,uint8_t bpc)
+{
   NV_HDR_COLOR_DATA color = {0};
 
   color.version = NV_HDR_COLOR_DATA_VER;
   color.cmd = NV_HDR_CMD_SET;
 
-  if (enabled) {
+  if (enabled)
+  {
     color.hdrColorFormat = NV_COLOR_FORMAT_RGB;
-    color.hdrBpc = NV_BPC_8;
+    switch (bpc) {
+    case 16:
+        color.hdrBpc = NV_BPC_16;
+        break;
+    case 12:
+        color.hdrBpc = NV_BPC_12;
+        break;
+    case 10:
+        color.hdrBpc = NV_BPC_10;
+        break;
+    case 6:
+        color.hdrBpc = NV_BPC_6;
+        break;
+    case 8:
+        color.hdrBpc = NV_BPC_8;
+        break;
+    default:
+    case 0:
+        color.hdrBpc = NV_BPC_DEFAULT;
+    }
+    
   }
 
   color.hdrDynamicRange = NV_DYNAMIC_RANGE_AUTO;
@@ -73,59 +113,70 @@ NV_HDR_COLOR_DATA HdrToggle::set_hdr_data(bool enabled) {
   return color;
 }
 
-bool HdrToggle::set_hdr_mode(bool enabled) {
+bool HdrToggle::set_hdr_mode(bool enabled,uint8_t bpc)
+{
   auto disp_ids_hdr = get_hdr_display_ids();
 
   std::vector<bool> statuses;
-  for (const auto &disp_id : disp_ids_hdr) {
-    auto color = set_hdr_data(enabled);
+  for (const auto &disp_id : disp_ids_hdr)
+  {
+    auto color = set_hdr_data(enabled, bpc);
     auto status = check_status_nothrow(NvAPI_Disp_HdrColorControl(disp_id.displayId, &color));
     statuses.push_back(status);
   }
 
-  if (std::any_of(std::begin(statuses), std::end(statuses), [](auto &s) { return s; })) {
+  if (std::any_of(std::begin(statuses), std::end(statuses), [](auto s) { return s; }))
+  {
     return true;
   }
   return false;
 }
 
-std::vector<NV_GPU_DISPLAYIDS> HdrToggle::get_hdr_display_ids() {
+std::vector<NV_GPU_DISPLAYIDS> HdrToggle::get_hdr_display_ids()
+{
   NvU32 disp_id_count = 0;
 
   auto gpu_handles = std::vector<NvPhysicalGpuHandle>(NVAPI_MAX_PHYSICAL_GPUS);
   NvU32 num_of_gp_us = 0;
 
   auto status = check_status(NvAPI_EnumPhysicalGPUs(gpu_handles.data(), &num_of_gp_us));
-  if (!status) {
+  if (!status)
+  {
     return {};
   }
 
   NvU32 connected_displays = 0;
 
   status = check_status(NvAPI_GPU_GetConnectedDisplayIds(gpu_handles[0], NULL, &disp_id_count, NULL));
-  if (!status) {
+  if (!status)
+  {
     return {};
   }
 
   auto disp_ids = std::vector<NV_GPU_DISPLAYIDS>(disp_id_count);
-  for (auto &disp_id : disp_ids) {
+  for (auto &disp_id : disp_ids)
+  {
     disp_id.version = NV_GPU_DISPLAYIDS_VER;
   }
 
   status = check_status(NvAPI_GPU_GetConnectedDisplayIds(gpu_handles[0], disp_ids.data(), &disp_id_count, NULL));
-  if (!status) {
+  if (!status)
+  {
     return {};
   }
 
   std::vector<NV_GPU_DISPLAYIDS> display_ids_hdr;
-  for (auto &disp_id : disp_ids) {
+  for (auto &disp_id : disp_ids)
+  {
     NV_HDR_CAPABILITIES hdr_capabilities;
     hdr_capabilities.version = NV_HDR_CAPABILITIES_VER;
     status = check_status(NvAPI_Disp_GetHdrCapabilities(disp_id.displayId, &hdr_capabilities));
-    if (!status) {
+    if (!status)
+    {
       return {};
     }
-    if (hdr_capabilities.isST2084EotfSupported == 1) {
+    if (hdr_capabilities.isST2084EotfSupported == 1)
+    {
       display_ids_hdr.push_back(disp_id);
     }
   }

--- a/src/hdr_toggle.hpp
+++ b/src/hdr_toggle.hpp
@@ -1,25 +1,26 @@
 #pragma once
-#include <stdexcept>
 #include <vector>
+#include <stdexcept>
 #include <nvapi.h>
 
-bool _check_status(const NvAPI_Status &s, const std::string &message, bool should_raise = true);
+bool _check_status(const NvAPI_Status& s, const std::string& message, bool should_raise = true);
 #define check_status(s) _check_status(s, std::string(__func__) + "," + std::to_string(__LINE__) + ": ");
 #define check_status_nothrow(s) _check_status(s, std::string(__func__) + "," + std::to_string(__LINE__) + ": ", false);
 
 struct NvapiException : public std::runtime_error {
-  explicit NvapiException(const std::string &what) : std::runtime_error(what) {}
-  explicit NvapiException(const char *what) : std::runtime_error(what) {}
+  explicit NvapiException(const std::string& what) : std::runtime_error(what) {}
+  explicit NvapiException(const char* what) : std::runtime_error(what) {}
 };
 
-class HdrToggle {
+class HdrToggle
+{
 public:
+
   HdrToggle();
   virtual ~HdrToggle();
-  bool set_hdr_mode(bool enabled);
-
+  bool set_hdr_mode(bool enabled, uint8_t bpc);
 private:
-  NV_HDR_COLOR_DATA set_hdr_data(bool enabled);
+  NV_HDR_COLOR_DATA set_hdr_data(bool enabled,uint8_t bpc);
   std::vector<NV_GPU_DISPLAYIDS> get_hdr_display_ids();
   void calc_mastering_data(NV_HDR_COLOR_DATA *hdr_data);
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,17 +2,15 @@
 #pragma warning(disable : 4244)
 #include <boost/process.hpp>
 #pragma warning(pop)
+#define VC_EXTRALEAN 1
 #include "windows.h"
 #include <boost/property_tree/ini_parser.hpp>
-#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <optional>
-#include <sstream>
 #include <string>
 
-#include "WinReg.hpp"
 #include "hdr_toggle.hpp"
 
 #ifdef SENTRY_DEBUG
@@ -29,13 +27,16 @@ namespace fs = std::filesystem;
 namespace pt = boost::property_tree;
 using namespace std::string_literals;
 
-const static std::string default_launcher = "C:/Program Files (x86)/GOG Galaxy/GalaxyClient.exe";
+static const std::string default_launcher = "C:/Program Files (x86)/GOG Galaxy/GalaxyClient.exe"s;
 
-DEVMODE const get_primary_display_registry_settings() {
-  DEVMODE devmode{};
-  devmode.dmSize = sizeof(devmode);
-  EnumDisplaySettings(nullptr, ENUM_REGISTRY_SETTINGS, &devmode);
-  return devmode;
+
+std::optional<DEVMODE> const get_primary_display_registry_settings() {
+    DEVMODE devmode{};
+    devmode.dmSize = sizeof(devmode);
+    if (EnumDisplaySettings(nullptr, ENUM_REGISTRY_SETTINGS, &devmode)) {
+        return devmode;
+    }
+    return {};
 }
 
 DWORD get_max_refresh_rate(uint16_t width, uint16_t height) {
@@ -68,19 +69,19 @@ LONG _ChangeDisplaySettings(DEVMODE *devmode, DWORD dwFlags) {
 }
 
 template <typename log_function>
-void set_resolution(uint16_t width, uint16_t height, uint16_t refresh_rate, bool wait_on_process, bool refresh_rate_use_max, log_function log_func) {
+void set_resolution(uint16_t width, uint16_t height, uint16_t refresh_rate, bool wait_on_process, bool refresh_rate_use_max, log_function log) {
   DEVMODE devmode{};
   devmode.dmSize = sizeof(devmode);
   devmode.dmPelsWidth = width;
   devmode.dmPelsHeight = height;
   devmode.dmFields = DM_PELSHEIGHT | DM_PELSWIDTH;
   if (refresh_rate == 0 && refresh_rate_use_max) {
-    log_func("Setting max refresh_rate"s);
+    log("setting max refresh_rate"s);
     refresh_rate = get_max_refresh_rate(width, height);
-    log_func("Detected max refresh rate: "s + std::to_string(refresh_rate));
+    log("Detected max refresh rate: "s + std::to_string(refresh_rate));
   } else {
     if (refresh_rate_use_max) {
-      log_func("refresh_rate and refresh_rate_use_max specified, defaulting to specified rate"s);
+      log("refresh_rate and refresh_rate_use_max specified, defaulting to specified rate"s);
     }
   }
   if (refresh_rate != 0) {
@@ -96,11 +97,12 @@ void set_resolution(uint16_t width, uint16_t height, uint16_t refresh_rate, bool
     result = _ChangeDisplaySettings(&devmode, 0);
   }
   if (result != DISP_CHANGE_SUCCESSFUL) {
-    log_func("ChangeDisplaySettings failed error:" + std::to_string(result));
+    log("ChangeDisplaySettings failed error:"s + std::to_string(result));
   }
 }
 
-void log(const std::string &message, std::ofstream &file, bool log_to_stdout = true) {
+void log_func(const std::string &message, std::ofstream &file,
+              bool log_to_stdout = true) {
   auto now = std::chrono::system_clock::now();
   auto in_time_t = std::chrono::system_clock::to_time_t(now);
   auto time = std::put_time(std::localtime(&in_time_t), "%Y-%m-%d %X");
@@ -111,18 +113,26 @@ void log(const std::string &message, std::ofstream &file, bool log_to_stdout = t
   file.flush();
 }
 
-std::optional<fs::path> get_destination_folder_path() {
-  winreg::RegKey key;
-  auto result = key.TryOpen(HKEY_CURRENT_USER, L"SOFTWARE\\lyckantropen\\moonlight_hdr_launcher");
-  if (result) {
-    if (auto dest_path = key.TryGetStringValue(L"destination_folder")) {
-      return fs::path(*dest_path);
-    } else {
-      return {};
-    }
-  } else {
-    return {};
+template <typename log_function>
+std::optional<fs::path> get_destination_folder_path(log_function log) {
+  HKEY hkey;
+  static constexpr size_t buf_size = 4096;//we are getting a path, I believe windows doesn't allow paths past 255 chars anyway
+  wchar_t recv_buffer[buf_size];
+  DWORD recv_buffer_size = buf_size * sizeof(wchar_t);
+  auto status = RegOpenKeyEx(HKEY_CURRENT_USER,
+                             L"SOFTWARE\\lyckantropen\\moonlight_hdr_launcher",
+                             REG_NONE, KEY_READ | KEY_QUERY_VALUE, &hkey);
+  if (status == ERROR_SUCCESS) {
+    status = RegGetValue(hkey, nullptr, L"destination_folder", RRF_RT_REG_SZ,
+                         nullptr, &recv_buffer, &recv_buffer_size);
+    if (status == ERROR_SUCCESS)
+      return fs::path(recv_buffer);
+    if (recv_buffer_size > buf_size * sizeof(wchar_t))
+      log("insallation path in registry is too long");//we could dynamically allocate a large enough buffer and try again
+	//but it seems like a waste of code as paths should never be too long to fit in our buffer.
   }
+  log("could not find installation path in registry");
+  return {};
 }
 
 class DummyWindow {
@@ -154,12 +164,14 @@ public:
       // Parse the menu selections:
       switch (wmId) {
       case 105: // IDM_EXIT
+        PostQuitMessage(0);  
         break;
       default:
         return DefWindowProc(hWnd, message, wParam, lParam);
       }
     } break;
     case WM_DESTROY:
+      PostQuitMessage(0);
       break;
     default:
       return DefWindowProc(hWnd, message, wParam, lParam);
@@ -177,14 +189,19 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine,
   auto argv = __argv;
 
   auto pwd = fs::path(argv[0]).parent_path();
-  auto reg_dest_path = get_destination_folder_path();
+  auto log_path = pwd / fs::path("moonlight_hdr_launcher_log.txt");
+  auto logfile = std::ofstream{log_path.string()};
+  auto log = [&logfile](std::string message,
+                        bool log_to_stdout = true) -> void {
+    log_func(message, logfile, log_to_stdout);
+  };
+
+  auto reg_dest_path = get_destination_folder_path(log);
 
   if (reg_dest_path) {
     pwd = *reg_dest_path;
   }
 
-  auto log_path = pwd / fs::path("moonlight_hdr_launcher_log.txt");
-  auto logfile = std::ofstream{log_path.string()};
   auto inifile = pwd / fs::path("moonlight_hdr_launcher.ini");
 
 #ifdef SENTRY_DEBUG
@@ -205,14 +222,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine,
   sentry_add_breadcrumb(inifile_c);
 #endif
 
-  log("Moonlight HDR Launcher Version "s + std::string(MHDRL_VERSION), logfile);
+  log("Moonlight HDR Launcher Version "s + std::string(MHDRL_VERSION));
 
   if (reg_dest_path) {
-    log("Working folder read from registry: "s + pwd.string(), logfile);
+    log("Working folder read from registry: "s + pwd.string());
   }
 
   for (int i = 0; i < argc; ++i) {
-    log(std::string("argv[") + std::to_string(i) + std::string("]: ") + std::string(argv[i]), logfile);
+    log("argv["s + std::to_string(i) + "]: "s + std::string(argv[i]));
   }
 
   int retcode = 1;
@@ -220,21 +237,24 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine,
   try
 #endif
   {
-    log("Setting current working directory to "s + pwd.string(), logfile);
+    log("Setting current working directory to "s + pwd.string());
     fs::current_path(pwd);
 
     std::string launcher_exe = default_launcher;
     bool wait_on_process = true;
     bool toggle_hdr = false;
+    bool enable_hdr = false;//toggle_hdr but don't bother to turn it off at the end
     uint16_t res_x = 0;
     uint16_t res_y = 0;
     uint16_t refresh_rate = 0;
     bool refresh_rate_use_max = true;
+    bool disable_reset_display_mode = false;
     bool remote_desktop = false;
     bool compatibility_window = true;
+    uint8_t hdr_bpc = 0;
 
     if (fs::exists(inifile)) {
-      log("Found config file: "s + inifile.string(), logfile);
+      log("Found config file: "s + inifile.string());
 
       std::ifstream ini_f{inifile.c_str()};
       pt::ptree ini;
@@ -243,29 +263,53 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine,
       launcher_exe = ini.get_optional<std::string>("options.launcher_exe").get_value_or(""s);
       wait_on_process = ini.get_optional<bool>("options.wait_on_process").get_value_or(wait_on_process);
       toggle_hdr = ini.get_optional<bool>("options.toggle_hdr").get_value_or(toggle_hdr);
+      enable_hdr = ini.get_optional<bool>("options.enable_hdr").get_value_or(enable_hdr);
       res_x = ini.get_optional<uint16_t>("options.res_x").get_value_or(res_x);
       res_y = ini.get_optional<uint16_t>("options.res_y").get_value_or(res_y);
       refresh_rate = ini.get_optional<uint16_t>("options.refresh_rate").get_value_or(refresh_rate);
       refresh_rate_use_max = ini.get_optional<bool>("options.refresh_rate_use_max").get_value_or(refresh_rate_use_max);
+      disable_reset_display_mode = ini.get_optional<bool>("options.disable_reset_display_mode").get_value_or(false);
       remote_desktop = ini.get_optional<bool>("options.remote_desktop").get_value_or(remote_desktop);
+      hdr_bpc = ini.get_optional<uint8_t>("options.hdr_bpc").get_value_or(0);
+
+      switch (hdr_bpc) {//This switch is uglier than a constexpr container and an algorithm check
+			//but with winRel compiler options this produces smaller code 
+      case 0:
+      case 6:
+      case 8:
+      case 10:
+      case 12:
+      case 16:
+        break;
+      default:
+        log("unsupported bits per colour channel setting. Possible settings (manually confirm what your graphics card / display support): 0 (default), 6,8,10,12,16\nsetting to default"s);
+        hdr_bpc = 0;
+      }
+
+      log("hdr bits per colour channel set to:"s + std::to_string(hdr_bpc));
+
+      if (enable_hdr && toggle_hdr) {
+        log("enable_hdr and toggle_hdr specified defaulting to toggle_hdr"s);
+        enable_hdr = false;
+      }
+
       compatibility_window = ini.get_optional<bool>("options.compatibility_window").get_value_or(compatibility_window);
       if (launcher_exe != ""s) {
-        if (remote_desktop) {
-          log("remote_desktop and launcher_exe both specified, defaulting to launcher_exe"s, logfile);
-        }
+        if (remote_desktop)
+          log("remote_desktop and launcher_exe both specified defaulting to launcher_exe"s);
         remote_desktop = false;
       }
       if (!remote_desktop && launcher_exe == ""s) {
         launcher_exe = default_launcher;
       }
       if (remote_desktop && !compatibility_window) {
-        log("compatibility_window required for remote_desktop, setting to true"s, logfile);
+        log("compatibility_window required for remote_desktop, setting to true"s);
         compatibility_window = true;
       }
 
-      log("options.launcher_exe="s + launcher_exe, logfile);
-      log("options.wait_on_process="s + std::to_string(wait_on_process), logfile);
-      log("options.toggle_hdr="s + std::to_string(toggle_hdr), logfile);
+      log("options.launcher_exe="s + launcher_exe);
+      log("options.wait_on_process="s + std::to_string(wait_on_process));
+      log("options.toggle_hdr="s + std::to_string(toggle_hdr));
 
 #ifdef SENTRY_DEBUG
       sentry_value_t le_c = sentry_value_new_breadcrumb("default", "launcher_exe");
@@ -273,16 +317,39 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine,
       sentry_add_breadcrumb(le_c);
 #endif
     }
+    std::optional<HdrToggle> hdr_toggle;
+    if (enable_hdr) {
+      log("Attempting to set HDR mode"s);
+#ifndef SENTRY_DEBUG
+      try
+#endif
+      {
+        hdr_toggle = HdrToggle{};
+        if (!hdr_toggle->set_hdr_mode(true, hdr_bpc)) {
+          log("Failed to set HDR mode"s);
+        }
+      }
+#ifndef SENTRY_DEBUG
+      catch (NvapiException &e) {
+        log("Failed to set HDR mode: "s + e.what());
+      }
+#endif
+    }
 
     // set display mode
     std::optional<DEVMODE> original_display_mode;
     if (res_x != 0 && res_y != 0) {
       original_display_mode = get_primary_display_registry_settings();
-      log("Original display mode: "s + std::to_string(original_display_mode->dmPelsWidth) + "x"s + std::to_string(original_display_mode->dmPelsHeight) + "@"s +
-              std::to_string(original_display_mode->dmDisplayFrequency),
-          logfile);
-      log("Setting display mode: "s + std::to_string(res_x) + "x"s + std::to_string(res_y) + "@"s + std::to_string(refresh_rate), logfile);
-      set_resolution(res_x, res_y, refresh_rate, wait_on_process, refresh_rate_use_max, [&logfile](std::string a) -> void { log(a, logfile); });
+      if (original_display_mode) {
+          log("Original display mode: "s + std::to_string(original_display_mode->dmPelsWidth) + "x"s + std::to_string(original_display_mode->dmPelsHeight) + "@"s +
+              std::to_string(original_display_mode->dmDisplayFrequency));
+      }
+      else {
+          log("Error getting original display mode"s);
+      }
+      log("Setting display mode: "s + std::to_string(res_x) + "x"s + std::to_string(res_y) + "@"s + std::to_string(refresh_rate));
+      set_resolution(res_x, res_y, refresh_rate, wait_on_process,
+                     refresh_rate_use_max, log);
     }
 
     if (wait_on_process) {
@@ -293,19 +360,19 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine,
 
       std::optional<HdrToggle> hdr_toggle;
       if (toggle_hdr) {
-        log("Attempting to set HDR mode", logfile);
+        log("Attempting to set HDR mode"s);
 #ifndef SENTRY_DEBUG
         try
 #endif
         {
           hdr_toggle = HdrToggle{};
-          if (!hdr_toggle->set_hdr_mode(true)) {
-            log("Failed to set HDR mode", logfile);
+          if (!hdr_toggle->set_hdr_mode(true, hdr_bpc)) {
+            log("Failed to set HDR mode"s);
           }
         }
 #ifndef SENTRY_DEBUG
         catch (NvapiException &e) {
-          log("Failed to set HDR mode: "s + e.what(), logfile);
+          log("Failed to set HDR mode: "s + e.what());
         }
 #endif
       }
@@ -313,22 +380,26 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine,
       if (remote_desktop) {
         launcher_window->message_loop();
       } else {
-        log("Launching '"s + launcher_exe + "' and waiting for it to complete."s, logfile);
+        log("Launching '"s + launcher_exe + "' and waiting for it to complete."s);
         bp::ipstream is; // reading pipe-stream
         try {
           auto c = bp::child{launcher_exe, bp::std_out > is, bp::std_err > is};
           while (c.running()) {
             std::string line;
             if (std::getline(is, line) && !line.empty()) {
-              log("SUBPROCESS: "s + line, logfile);
+              log("SUBPROCESS: "s + line);
             }
           }
           c.wait();
           if (c.exit_code() != 0) {
-            log(std::string("The command \"") + launcher_exe + std::string("\" has terminated with exit code ") + std::to_string(c.exit_code()), logfile);
+            log("The command \""s + launcher_exe +
+                "\" has terminated with exit code "s +
+                std::to_string(c.exit_code()));
           }
         } catch (bp::process_error const &e) {
-          log("Error executing command. Error code: "s + std::to_string(e.code().value()) + ", message: " + e.code().message(), logfile);
+          log("Error executing command. Error code: "s +
+              std::to_string(e.code().value()) + ", message: "s +
+              e.code().message());
 #ifdef SENTRY_DEBUG
           sentry_value_t exc = sentry_value_new_object();
           sentry_value_set_by_key(exc, "type", sentry_value_new_string("bp::process_error"));
@@ -342,30 +413,31 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine,
       }
 
       if (toggle_hdr) {
-        log("Attempting to disable HDR mode", logfile);
+        log("Attempting to disable HDR mode"s);
         try {
-          hdr_toggle->set_hdr_mode(false);
+          hdr_toggle->set_hdr_mode(false, hdr_bpc);
         } catch (NvapiException &e) {
-          log("Failed to disable HDR mode: "s + e.what(), logfile);
+          log("Failed to disable HDR mode: "s + e.what());
         }
       }
-      if (original_display_mode) {
-        log("Resetting to original display mode", logfile);
+      if (original_display_mode && !disable_reset_display_mode) {
+        log("Resetting to original display mode");
         _ChangeDisplaySettings(&original_display_mode.value(), CDS_UPDATEREGISTRY);
       }
+
     } else {
-      log("Launching '"s + launcher_exe + "' and detaching immediately."s, logfile);
+      log("Launching '"s + launcher_exe + "' and detaching immediately."s);
       bp::spawn(launcher_exe);
     }
     retcode = 0;
   }
 #ifndef SENTRY_DEBUG
   catch (std::runtime_error &e) {
-    log("Error: "s + std::string(e.what()), logfile);
+    log("Error: "s + std::string(e.what()));
   } catch (std::exception &e) {
-    log("Error: "s + std::string(e.what()), logfile);
+    log("Error: "s + std::string(e.what()));
   } catch (...) {
-    log("Unknown error", logfile);
+    log("Unknown error"s);
   }
 #endif
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,6 +5,5 @@
         "boost-filesystem",
         "boost-process",
         "boost-property-tree"
-    ],
-    "builtin-baseline": "876e67c26e42c0c7d2daa41c6871af117ae6bec5"
+    ]
 }


### PR DESCRIPTION
I added the option to not bother turning off HDR at the end of the session and to set the bits per channel for HDR. If it isn't specified the graphics driver default is now used instead of 8. 

BTW What IDE are you using? I'm using visual studio, our linters definitely aren't lined up and the visual studio clang format plugin I found doesn't seem compatible with vs2022. I normally develop on linux so I'm just sort of winging it tool wise for this project. 

I removed the baseline altogether for boost as I've never used vcpkg before and couldn't figure out the right value to update it to a version that vs2022 supports. I had changed the CMakeLists.txt to use the latest nvapi but it looks like you've totally reworked that part to work differently anyway.

 
